### PR TITLE
feat(ExistClient): allow setting a custom base_url

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Black">
+    <option name="enabledOnReformat" value="true" />
+    <option name="enabledOnSave" value="true" />
+    <option name="executionMode" value="BINARY" />
+    <option name="pathToExecutable" value="$USER_HOME$/.local/bin/black" />
     <option name="sdkName" value="Poetry (exist-client)" />
   </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (exist-client)" project-jdk-type="Python SDK" />

--- a/src/exist_client/client.py
+++ b/src/exist_client/client.py
@@ -35,9 +35,9 @@ PaginatedApi = Callable[..., Optional[PaginatedResponse[T]]]
 
 
 class ExistClient:
-    def __init__(self, *, token: str):
+    def __init__(self, *, token: str, base_url: str = EXIST_IO_BASE_URL):
         self.client = AuthenticatedClient(
-            EXIST_IO_BASE_URL,
+            base_url,
             token,
             raise_on_unexpected_status=True,
             follow_redirects=True,


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 06a20dc007b013d0fed18ba57029129c97f92901  | 
|--------|

### Summary:
This PR allows setting a custom `base_url` for `ExistClient`, enhancing flexibility for different environments, and updates Black formatter settings.

**Key points**:
- Added `base_url` parameter to `ExistClient` constructor in `/src/exist_client/client.py`
- `base_url` defaults to `EXIST_IO_BASE_URL`
- `AuthenticatedClient` initialization now uses `base_url`
- Updated Black formatter settings in `/.idea/misc.xml`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
